### PR TITLE
Don't decay mixer

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,17 @@
-export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4
-export TF_CPP_MIN_LOG_LEVEL=4
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4  # faster malloc
+export TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=60000000000  # no numpy memory warnings
+export TF_CPP_MIN_LOG_LEVEL=4   # no dataset warnings
+
 export XRT_TPU_CONFIG="localservice;0;localhost:51011"
-export XLA_FLAGS="--xla_force_host_platform_device_count=48"
-export TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=60000000000
-export JAX_ENABLE_X64=0  # forces parameters into fp64
-export JAX_DEFAULT_DTYPE_BITS=32
-export WANDB_WATCH="false"
+
+export JAX_ENABLE_X64=1  # allow fp64
+export JAX_DEFAULT_DTYPE_BITS=32  # ..but don't enforce it
+
+export WANDB_WATCH="false"  # workaround to wandb crashing and killing the whole run
 export WANDB_START_METHOD="thread"
+
+# https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/xla.proto
+export XLA_FLAGS="--xla_force_host_platform_device_count=1"  # We don't use TPU-CPU for ML
+# export XLA_FLAGS="--xla_step_marker_location=1 $XLA_FLAGS"  # 0 = entry; 1 = outer while
+
 /usr/bin/env python3 main.py "$@"

--- a/src/context.py
+++ b/src/context.py
@@ -238,7 +238,7 @@ class WhileContext(DataClass):
 class WhileTrainContext(WhileContext):
     def __init__(self, config: typing.Optional[typing.Dict[str, typing.Any]] = None):
         super().__init__(config)
-        self.scalars = jnp.zeros([4], jnp.float64)
+        self.scalars = jnp.zeros([2], jnp.float64)
 
         if config is not None:
             self.scalars = config['scalars']

--- a/src/context.py
+++ b/src/context.py
@@ -109,16 +109,13 @@ class WandB(DataClass):
 class Optimizer(DataClass):
     nesterov: bool = True
     heavyball: bool = True
-    block_size: int = 512
     epsilon: float = 1e-16
-    statistics_compute_steps: int = 4
-    momentum_beta: float = 0.1
     learning_rate: float = 0.01
     gradient_clip: float = 0.001
     adam_beta1: float = 0.03
     adam_beta2: float = 0.003
-    adam_beta3: float = 0.001
     weight_decay: float = 0.01
+    adam_beta3: float = 0.001
     warmup_end: int = 16384
     exponential_decay: float = 3e-6
 
@@ -241,18 +238,15 @@ class WhileContext(DataClass):
 class WhileTrainContext(WhileContext):
     def __init__(self, config: typing.Optional[typing.Dict[str, typing.Any]] = None):
         super().__init__(config)
-        self.loss = jnp.zeros([])
-        self.accuracy = jnp.zeros([])
+        self.scalars = jnp.zeros([4], jnp.float64)
 
         if config is not None:
-            self.loss = config['loss']
-            self.accuracy = config['accuracy']
+            self.scalars = config['scalars']
             self.ctx.parameter_variance = config['parameter_variance']
 
     def serialize(self):
         serialized = self._serialize()
-        serialized['loss'] = self.loss
-        serialized['accuracy'] = self.accuracy
+        serialized['scalars'] = self.scalars
         serialized['parameter_variance'] = self.ctx.parameter_variance
         return serialized
 

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ import numpy as np
 import wandb
 from jax import lax, numpy as jnp
 
-from src.backend import deep_replace, device_id, loop, add_sq
+from src.backend import add_sq, deep_replace, device_id, loop
 from src.constants import ParallelAxes
 from src.context import Context, WhileTrainContext, init_class
 from src.data import text_dataset
@@ -18,8 +18,6 @@ from src.model.main import body_ctx, compute
 from src.optimizer import get_current_lr, update
 from src.utils.checkpoint import read_train_checkpoint, write_train_checkpoint
 from src.utils.wandblog import WandbLog
-
-jax.distributed.initialize()
 
 
 def add_zeros(params: typing.Dict[str, jnp.ndarray]):

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -12,7 +12,7 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, in_features: int, out
     fan_in = (1 - 1 / (conv_kernel * ctx.model.conv_scale + ctx.model.conv_shift)) ** fan_in
     fan_in = fan_in / fan_in.sum()
     fan_in = fan_in.reshape(1, 1, -1)
-    weight = get_param(ctx, "weight", [out_features, conv_kernel, in_features], column_axes=2, lr_scale=fan_in,
+    weight = get_param(ctx, "conv_weight", [out_features, conv_kernel, in_features], column_axes=2, lr_scale=fan_in,
                        tied=tied)
     if ctx.is_initializing:
         return jnp.zeros(inp.shape[:-1] + (out_features,), dtype=inp.dtype)

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -12,15 +12,15 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, in_features: int, out
     fan_in = (1 - 1 / (conv_kernel * ctx.model.conv_scale + ctx.model.conv_shift)) ** fan_in
     fan_in = fan_in / fan_in.sum()
     fan_in = fan_in.reshape(1, 1, -1)
-    weight = get_param(ctx, "conv_weight", [out_features, conv_kernel, in_features], column_axes=2, lr_scale=fan_in,
-                       tied=tied)
+    weight, weight_sq = get_param(ctx, "conv_weight", [out_features, conv_kernel, in_features], column_axes=2,
+                                  lr_scale=fan_in, tied=tied, return_sq=True)
     if ctx.is_initializing:
         return jnp.zeros(inp.shape[:-1] + (out_features,), dtype=inp.dtype)
 
     def _conv(x, y):
         return lax_conv(x, y, [(conv_kernel - 1, 0)], 1)
 
-    return square_grad(_conv, inp, weight, get_param(ctx, "weight_sq", tied=tied))
+    return square_grad(_conv, inp, weight, weight_sq)
 
 
 @prenorm

--- a/src/model/loss.py
+++ b/src/model/loss.py
@@ -72,7 +72,7 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
             return (dx * dy).astype(inp.dtype), None, (d_wgt * dy).astype(wgt.dtype), (d_wgt_sq * dy).astype(wgt.dtype)
 
         loss = lax.psum(loss, ParallelAxes.model)
-        accuracy = lax.psum(accuracy, ParallelAxes.model)
-        return (loss.astype(jnp.float64), accuracy.astype(jnp.float32)), _grad
+        acc = lax.psum(acc, ParallelAxes.model)
+        return (loss.astype(jnp.float64), acc.astype(jnp.float32)), _grad
 
     return _fn(src, outer_tgt, param, param_sq)

--- a/src/model/loss.py
+++ b/src/model/loss.py
@@ -23,7 +23,7 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
 
     def _xent_slice(carry: typing.Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray],
                     x: typing.Tuple[jnp.ndarray, jnp.ndarray], wgt: jnp.ndarray):
-        d_wgt, d_wgt_sq, loss, accuracy = carry
+        d_wgt, d_wgt_sq, loss, acc = carry
         inp_slice, tgt_slice = x
         tmp = matmul(inp_slice, wgt)
         tmp = promote_to(tmp, jnp.float32)
@@ -32,7 +32,7 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
 
         loss = loss + (lse / total_items).sum()
         loss = loss - (jnp.take_along_axis(tmp, tgt_slice.reshape(*tgt_slice.shape, 1), -1) / total_items).sum()
-        accuracy = accuracy + lax.eq(lax.argmax(tmp, 1, outer_tgt.dtype), tgt_slice).sum() / total_items
+        acc = acc + lax.eq(lax.argmax(tmp, 1, outer_tgt.dtype), tgt_slice).sum() / total_items
 
         dy = lax.exp(tmp - (lse + math.log(total_items)))  # [LocalBatch, Vocab]
         zloss = dy * lse * ctx.training.z_loss * 2
@@ -47,7 +47,7 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
         inp_slice = inp_slice.reshape(step_batch, ctx.dims.features)
         d_wgt = d_wgt + matmul(dy, inp_slice)  # [Vocab, StepBatch] @ [StepBatch, Features] -> [Vocab, Features]
         d_wgt_sq = d_wgt_sq + matmul(lax.square(dy), lax.square(inp_slice))
-        return (d_wgt, d_wgt_sq, loss, accuracy), dx
+        return (d_wgt, d_wgt_sq, loss.astype(jnp.float64), acc.astype(jnp.float64)), dx
 
     @jax.custom_gradient
     def _fn(inp: jnp.ndarray, tgt: jnp.ndarray, wgt: jnp.ndarray, wgt_sq: jnp.ndarray):
@@ -58,8 +58,8 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
         def _slice_fn(carry, x):
             return _xent_slice(carry, x, wgt)
 
-        init = (jnp.zeros(wgt.shape[::-1]), jnp.zeros(wgt.shape[::-1]), jnp.zeros(()), jnp.zeros(()))
-        (d_wgt, d_wgt_sq, loss, accuracy), dx = lax.scan(_slice_fn, init, (inp, tgt))
+        init = (jnp.zeros(wgt.shape[::-1]), jnp.zeros(wgt.shape[::-1]), jnp.zeros((), dtype=jnp.float64), jnp.zeros((), dtype=jnp.float64))
+        (d_wgt, d_wgt_sq, loss, acc), dx = lax.scan(_slice_fn, init, (inp, tgt))
 
         dx = dx.transpose(0, 2, 1)  # [Steps, Features, StepBatch] -> [Steps, StepBatch, Features]
         dx = dx.reshape(ctx.dims.batch, ctx.dims.sequence, ctx.dims.features)
@@ -73,6 +73,6 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
 
         loss = lax.psum(loss, ParallelAxes.model)
         accuracy = lax.psum(accuracy, ParallelAxes.model)
-        return (loss.astype(jnp.float32), accuracy.astype(jnp.float32)), _grad
+        return (loss.astype(jnp.float64), accuracy.astype(jnp.float32)), _grad
 
     return _fn(src, outer_tgt, param, param_sq)

--- a/src/model/mixer.py
+++ b/src/model/mixer.py
@@ -21,15 +21,11 @@ def dot_sq(src: jnp.ndarray, weight: jnp.ndarray, weight_sq: jnp.ndarray,
 def mix(ctx: Context, inp: jnp.ndarray, depth: jnp.ndarray) -> jnp.ndarray:
     weight_shape = [ctx.dims.spatial_mixing_kernel] * 2
     run_type = jnp.promote_types(ctx.model.computation_dtype, jnp.float32)
-    wgt0 = get_param(ctx, "mix_0", weight_shape)
-    wgt1 = get_param(ctx, "mix_1", weight_shape)
-    scale = get_param(ctx, "scale", [ctx.dims.features], std=0, mean=1, dtype=run_type)
+    wgt0, wgt0_sq = get_param(ctx, "mix_0", weight_shape, return_sq=True)
+    wgt1, wgt1_sq = get_param(ctx, "mix_1", weight_shape, return_sq=True)
+    scale, scale_sq = get_param(ctx, "scale", [ctx.dims.features], std=0, mean=1, dtype=run_type, return_sq=True)
     if ctx.is_initializing:
         return inp
-
-    wgt0_sq = get_param(ctx, "mix_0_sq")
-    wgt1_sq = get_param(ctx, "mix_1_sq")
-    scale_sq = get_param(ctx, "scale_sq", dtype=run_type)
 
     original_shape = inp.shape
     _batch, sequence, _features = original_shape

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -56,9 +56,7 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int,
                    psum: bool = False, act: bool = True, dim: int = 2) -> jnp.ndarray:
     run_type = jnp.promote_types(ctx.model.computation_dtype, jnp.float32)
     if weight is None:
-        weight = get_param(ctx, "scale", [feature_dim], std=0, mean=1, dtype=run_type)
-        if not ctx.is_initializing:
-            weight_sq = get_param(ctx, "scale_sq", dtype=run_type)
+        weight, weight_sq = get_param(ctx, "scale", [feature_dim], std=0, mean=1, dtype=run_type, return_sq=True)
     elif weight is False:
         weight_sq = weight = 1
     else:

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -8,7 +8,8 @@ from .context import Context
 
 
 def small_parameter(param_name: str, grad: jnp.ndarray) -> bool:
-    is_small = "scale_norm_act" in param_name.lower() or "rezero" in param_name.lower()
+    param_name = param_name.lower()
+    is_small = any(f'/{k}' in param_name for k in ("scale_norm_act", "rezero", "mix"))
     is_small |= grad.ndim < (2 + is_stacked(param_name))
     return is_small
 

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -8,7 +8,7 @@ from .context import Context
 
 
 def small_parameter(param_name: str, grad: jnp.ndarray) -> bool:
-    is_small = "norm" in param_name.lower() or "rezero" in param_name.lower()
+    is_small = "scale_norm_act" in param_name.lower() or "rezero" in param_name.lower()
     is_small |= grad.ndim < (2 + is_stacked(param_name))
     return is_small
 

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -69,7 +69,7 @@ def write_checkpoint(ctx: Context, verbose: bool = True):
 def write_train_checkpoint(wctx: WhileTrainContext, verbose: bool = True):
     write_checkpoint(wctx.ctx, verbose)
     for shard in range(jax.local_device_count()):
-        for tree, suffix in ((wctx.loss, "loss"), (wctx.accuracy, "accuracy"), (wctx.current_step, "current_step")):
+        for tree, suffix in ((wctx.scalars, "scalars"), (wctx.current_step, "current_step")):
             write_shard([tree], shard, wctx.ctx.training.checkpoint_path, f"{suffix}.npz", verbose)
 
 
@@ -136,7 +136,6 @@ def read_checkpoint(ctx: Context, ignore: str = '.*optimizer.*', load_variance: 
 
 def read_train_checkpoint(wctx: WhileTrainContext, ignore: str = '.*optimizer.*'):
     _, structure = jax.tree_util.tree_flatten([jnp.zeros((1,))])
-    wctx.loss = _read_shards(wctx.ctx.training.checkpoint_load_path, structure, "loss")[0]
-    wctx.accuracy = _read_shards(wctx.ctx.training.checkpoint_load_path, structure, "accuracy")[0]
+    wctx.scalars = _read_shards(wctx.ctx.training.checkpoint_load_path, structure, "scalars")[0]
     wctx.current_step = _read_shards(wctx.ctx.training.checkpoint_load_path, structure, "current_step")[0]
     read_checkpoint(wctx.ctx, ignore, load_variance=True)

--- a/src/utils/wandblog.py
+++ b/src/utils/wandblog.py
@@ -44,11 +44,6 @@ class WandbLog:
         items.update(self._log("Loss", wctx.scalars[0, 0], sizes))
         items.update(self._log("Accuracy", wctx.scalars[0, 1], sizes))
 
-        failures = wctx.scalars[0, 2]
-        if not np.isnan(failures) and failures >= 0:
-            items.update(self._log("Inverse Failures", failures, sizes))
-            items.update(self._log("Inverse Failures %", failures / wctx.scalars[0, 3] / jax.device_count(), sizes))
-
         self.run.log(items, step=step)
 
         return any(val in (float("nan"), float("inf"), float("-inf")) for val in wctx.scalars[0, :])

--- a/src/utils/wandblog.py
+++ b/src/utils/wandblog.py
@@ -1,5 +1,8 @@
+import collections
 import time
+import typing
 
+import jax
 import numpy as np
 
 from src.context import WhileTrainContext
@@ -9,40 +12,43 @@ class WandbLog:
     def __init__(self, run, device_steps: int, param_count: int, tokens_per_step: int):
         self.start_time = time.time()
         self.run = run
-        self.losses = []
-        self.accuracies = []
-        self.loss_medians = []
+        self.scalars = collections.defaultdict(list)
         self.device_steps = device_steps
         self.param_count = param_count
         self.tokens_per_step = tokens_per_step
         self.first_step = None
 
+    def _log(self, prefix: str, value: float, sizes: typing.List[int]):
+        scalars = self.scalars[prefix]
+        scalars.append(value)
+        items = {f"{prefix}/Median{s * self.device_steps}": np.median(scalars[-s:]) for s in sizes}
+        self.scalars[prefix] = scalars[-max(sizes):]
+        items[f"{prefix}/Current"] = value
+        return items
+
     def __call__(self, wctx: WhileTrainContext, step: int, current_lr) -> bool:
-        ctx = wctx.ctx
-        curr_loss = wctx.loss[0]
-        sizes = [s // self.device_steps for s in ctx.wandb.median_sizes]
-        self.losses.append(curr_loss.astype(float))
-        self.accuracies.append((wctx.accuracy[0]).astype(float))
-        self.loss_medians.append(np.median(self.losses[-max(sizes):]))
-        self.losses = self.losses[-max(sizes):]
-        self.accuracies = self.accuracies[-max(sizes):]
-        self.loss_medians = self.loss_medians[-max(sizes):]
-
-        self.run.log({f"Loss/Median{s * self.device_steps}": np.median(self.losses[-s:]) for s in sizes}, step=step)
-        self.run.log({f"Accuracy/Median{s * self.device_steps}": np.median(self.accuracies[-s:]) for s in sizes},
-                     step=step)
-
         if self.first_step is None:
             self.first_step = step - self.device_steps
         rate = (step - self.first_step) / (time.time() - self.start_time)
+
+        ctx = wctx.ctx
+        sizes = [s // self.device_steps for s in ctx.wandb.median_sizes]
+
         tokens_per_day = 3600 * 24 * rate * ctx.dims.batch * ctx.dims.sequence
+        items = {"Optimizer/Learning Rate": current_lr,
+                 "Speed/Batches per Second": rate,
+                 "Speed/Tokens per Day": tokens_per_day,
+                 "Speed/Parameters * Tokens per Day": tokens_per_day * self.param_count,
+                 "Speed/Tokens Seen": step * self.tokens_per_step}
 
-        self.run.log({"Loss/Current": self.losses[-1], "Accuracy/Current": self.accuracies[-1],
-                      "Speed/Batches per Second": rate, "Speed/Tokens per Day": tokens_per_day,
-                      "Optimizer/Learning Rate": current_lr, "Optimizer/Beta1": ctx.optimizer.adam_beta1,
-                      "Optimizer/Beta2": ctx.optimizer.adam_beta2,
-                      "Speed/Parameters * Tokens per Day": tokens_per_day * self.param_count,
-                      "Speed/Tokens Seen": step * self.tokens_per_step
-                      }, step=step)
+        items.update(self._log("Loss", wctx.scalars[0, 0], sizes))
+        items.update(self._log("Accuracy", wctx.scalars[0, 1], sizes))
 
-        return self.losses[-1] in (float("nan"), float("inf"), float("-inf"))
+        failures = wctx.scalars[0, 2]
+        if not np.isnan(failures) and failures >= 0:
+            items.update(self._log("Inverse Failures", failures, sizes))
+            items.update(self._log("Inverse Failures %", failures / wctx.scalars[0, 3] / jax.device_count(), sizes))
+
+        self.run.log(items, step=step)
+
+        return any(val in (float("nan"), float("inf"), float("-inf")) for val in wctx.scalars[0, :])

--- a/unittests/consistency/step.py
+++ b/unittests/consistency/step.py
@@ -7,6 +7,7 @@ from jax import numpy as jnp
 from src.constants import ParallelAxes
 from src.context import WhileTrainContext
 from src.model.main import body_ctx
+from src.main import add_zeros
 
 
 def get_wctx(config: typing.Optional[typing.Dict[str, typing.Any]] = None):
@@ -37,7 +38,11 @@ def pmap(config: typing.Optional[typing.Dict[str, typing.Any]]):
         wctx, ctx = get_wctx(cfg)
         ctx.fail_on_missing_parameter = False
         ctx.is_initializing = config is None
+        add_zeros(ctx.parameters)
         _ = body_ctx(ctx, x)
+        for k in list(ctx.parameters.keys()):
+            if "optimizer" in k or k.endswith('_sq') or k.endswith('_sq_stacked'):
+                del ctx.parameters[k]
         name_cache.update(ctx.name_cache)
         parameter_usages.update(ctx.parameter_usages)
         return wctx.serialize()


### PR DESCRIPTION
It's the only one we can't decay. No mixer decay performs the same as decaying only input and output, which itself performs better than decay all non-norm parameters. This is likely why we couldn't reach the performance of the previous shampoo run again. However, I'm still in favor of merging adam-square as it's simpler than shampoo and significantly faster.