### PR TITLE
fix(optimizer): run all ops in fp64

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -42,8 +42,8 @@ def promote_to(inp: jax.Array, dtype: jnp.dtype) -> jax.Array:
     return jnp.asarray(inp, jnp.promote_types(dtype, jnp.result_type(inp)))
 
 
-def with_context(count: Optional[bool] = None) -> CtxFn:
-    def _inner(fn: CtxFn) -> CtxFn:
+def with_context(count: Optional[bool] = None):
+    def _inner(fn: CtxFn):
         prefix_kwargs = {"appended": fn.__name__}
         if count is not None:
             prefix_kwargs["count"] = count


### PR DESCRIPTION
the only "fix" that's net-positive (red vs green (not teal))
![grafik](https://user-images.githubusercontent.com/39779310/210012007-8263aa0f-2c02-4e33-aa9a-d09613aecbab.png)

However, still not as good as tied-moe :/